### PR TITLE
Revise query to .name gtld whois server to get nameserver data

### DIFF
--- a/whois/__init__.py
+++ b/whois/__init__.py
@@ -48,6 +48,9 @@ def query(domain, force=0, cache_file=None, slow_down=0, ignore_returncode=0):
         tld = 'co_jp'
     elif domain.endswith('.xn--p1ai'):
         tld = 'ru_rf'
+    elif domain.endswith('.name'):
+        d[0] = 'domain=' + d[0]
+        tld = d[-1]
     else:
         tld = d[-1]
 


### PR DESCRIPTION
From .NAME Agreement Appendix 5 Whois Specifications (https://www.icann.org/resources/unthemed-pages/appendix-05-2007-08-15-en) we can infer that to get nameserver data we must perform standard query for domain name.

The syntax for standard query for domain name is `domain=smith.name` as per the document. Therefore we must adjust the query to match the syntax.